### PR TITLE
SITELABELS-10 : fix core dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
         <dependency>
             <groupId>fr.paris.lutece</groupId>
             <artifactId>lutece-core</artifactId>
-            <version>[4.1.0,)</version>
+            <version>[4.2.0,)</version>
             <type>lutece-core</type>
         </dependency>
     </dependencies>


### PR DESCRIPTION
LabelJspBean#doModifyLabel calls redirect( request, VIEW_MODIFY_LABEL, mapParameters ),
which was introduced with library-mvc 1.2.0, which was included in core in 4.2.0-SNAPSHOT
